### PR TITLE
Add setup.py for easy packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 __pycache__/
 doc/_build/
+dist/
+MANIFEST

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+setup(name='ftrobopy',
+      description='Python Interface for Fischertechnik ROBOTICS TXT Controller',
+      version='0.94+git',
+      author='Torsten Stuehn',
+      author_email='Torsten Stuehn',
+      url='https://github.com/ftrobopy/ftrobopy',
+      license='MIT',
+      py_modules=['ftrobopy'],
+      )


### PR DESCRIPTION
The setup.py added by this patch makes it easy to package ftrobopy for distribution by simply running "python setup.py"

Currently, only ftrobopy.py is included in the distribution - inclusion of ftrobopytools still needs to be done.

Use case for me was integration of ftrobopy in https://github.com/ftCommunity/ftcommunity-TXT
