### PR TITLE
Make sound in direct mode compatible with python3 and ftcommunity-TXT

### DIFF
--- a/ftrobopy.py
+++ b/ftrobopy.py
@@ -166,6 +166,8 @@ class ftTXT(object):
         self._spi      = None
       if self._spi:
         self._spi.mode = 3
+        self._spi.bits_per_word = 8
+        self._spi.max_speed_hz = 1000000
         # reset sound on motor shield
         res = self._spi.xfer([self.C_SND_CMD_RESET, 0, 0])
         if res[0] != self.C_SND_MSG_RX_CMD:

--- a/ftrobopy.py
+++ b/ftrobopy.py
@@ -793,7 +793,7 @@ class ftTXT(object):
         with open(snd_file_name, 'rb') as f:
           buf = f.read()
           # first 44 bytes of ft soundfiles is header data
-          self._sound_data     = [ord(x) for x in buf[44:]]
+          self._sound_data     = list(buf[44:])
           filler = [0x80 for i in range(self.C_SND_FRAME_SIZE - (len(self._sound_data) % self.C_SND_FRAME_SIZE))]
           self._sound_data += filler
           self._sound_data_idx = 0


### PR DESCRIPTION
These changes are necessary to make sound in direct mode work with the community firmware as discussed [here](https://forum.ftcommunity.de/viewtopic.php?f=33&t=3942). 

I'm not sure if a410cf76e898c5f870e27fd0fbca692c38c4c8ab will work on python 2.7, though - can't test it myself, because I don't have a working spidev for python 2.7 on the TXT at the moment.

