### PR TITLE
Build ftrobopytools from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 
 setup(name='ftrobopy',
       description='Python Interface for Fischertechnik ROBOTICS TXT Controller',
-      version='0.94+git',
+      version='1.67',
       author='Torsten Stuehn',
       author_email='Torsten Stuehn',
       url='https://github.com/ftrobopy/ftrobopy',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from distutils.core import setup
+from distutils.core import setup, Extension
+
 setup(name='ftrobopy',
       description='Python Interface for Fischertechnik ROBOTICS TXT Controller',
       version='0.94+git',
@@ -7,4 +8,7 @@ setup(name='ftrobopy',
       url='https://github.com/ftrobopy/ftrobopy',
       license='MIT',
       py_modules=['ftrobopy'],
+      ext_modules=[Extension('ftrobopytools',
+                    sources = ['src/ftrobopytools.c'],
+                    libraries = ['SDL'])]
       )

--- a/src/ftrobopytools.c
+++ b/src/ftrobopytools.c
@@ -11,7 +11,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#include "SDL.h"
+#include <SDL/SDL.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // Begin of NanoJPEG


### PR DESCRIPTION
The patches from this pull request add the build instructions for ftrobopytools to setup.py.

My reason for this is integration of ftrobopytools with python3 in the community firmware (the binary ftrobopytools.so from the repository can't be used in FTC because it has been built for python2), and so far, I have only tested the changes in this context. But I don't think there will be compile problems in other contexts, as ftrobopytools is a fairly simple native extension and the setup.py entries for it are pretty much standard as well.
