### PR TITLE
initialisation bugfix

### DIFF
--- a/ftrobopy.py
+++ b/ftrobopy.py
@@ -1986,6 +1986,7 @@ class ftrobopy(ftTXT):
       s.close()
       return ok
         
+    self._txt_is_initialized = False
     if host[:4] == 'auto' or host == '127.0.0.1' or host == 'localhost':
       # first check if running on TXT:
       if str.find(socket.gethostname(), 'FT-txt') >= 0 or str.find(socket.gethostname(), 'ft-txt') >= 0:
@@ -2023,8 +2024,7 @@ class ftrobopy(ftTXT):
           else:
             print("Error: could not auto detect TXT connection. Please specify host and port manually !")
             return
-
-    self._txt_is_initialized = False
+          
     if host[:6] == 'direct':
       # check if running on FT-txt
       if str.find(socket.gethostname(), 'FT-txt') < 0 and str.find(socket.gethostname(), 'ft-txt') < 0:


### PR DESCRIPTION
Experienced the following issue:

Error: could not auto detect TXT connection. Please specify host and port manually !
Exception ignored in: <bound method ftrobopy.__del__ of <ftrobopy.ftrobopy object at 0x7f0434080358>>
Traceback (most recent call last):
  File "/home/apdent/public_html/ftrobopy.py", line 2063, in __del__
    if self._txt_is_initialized:
AttributeError: 'ftrobopy' object has no attribute '_txt_is_initialized'

seems to be fixed with this commit.