### PR TITLE
Fix spi error handling

### DIFF
--- a/ftrobopy.py
+++ b/ftrobopy.py
@@ -164,7 +164,7 @@ class ftTXT(object):
       import spidev
       try:
         self._spi      = spidev.SpiDev(1,0) # /dev/spidev1.0
-      except error:
+      except:
         print("Error opening SPI device (this is needed for sound in 'direct'-mode).")
         # print(error)
         self._spi      = None


### PR DESCRIPTION
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ftc/ftrobopy.py", line 2108, in __init__
    ftTXT.__init__(self, directmode=True)
  File "/home/ftc/ftrobopy.py", line 167, in __init__
    except error:
NameError: name 'error' is not defined